### PR TITLE
新增对话存储与多轮对话支持

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -104,6 +104,18 @@ class FavoriteVideo(Base):
     created_at = Column(DateTime, default=datetime.utcnow)
 
 
+class Conversation(Base):
+    """对话会话表"""
+    __tablename__ = "conversations"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    session_id = Column(String(64), index=True, nullable=False)
+    title = Column(String(200), nullable=True)
+    messages = Column(JSON, nullable=False, default=list)  # [{role, content, timestamp}]
+    created_at = Column(DateTime, default=datetime.utcnow)
+    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+
 # ==================== Pydantic 模型 (API 用) ====================
 
 class ContentSource(str, Enum):
@@ -164,9 +176,11 @@ class ChatRequest(BaseModel):
     question: str
     session_id: Optional[str] = None
     folder_ids: Optional[list[int]] = None  # 指定收藏夹，None 表示全部
+    conversation_id: Optional[int] = None
 
 
 class ChatResponse(BaseModel):
     """对话响应"""
     answer: str
     sources: list[dict]  # 来源视频列表
+    conversation_id: Optional[int] = None

--- a/app/routers/chat.py
+++ b/app/routers/chat.py
@@ -14,11 +14,14 @@ from openai import OpenAI
 from langchain.schema import Document
 
 from app.database import get_db
-from app.models import ChatRequest, ChatResponse, FavoriteFolder, FavoriteVideo, VideoCache
+from app.models import ChatRequest, ChatResponse, FavoriteFolder, FavoriteVideo, VideoCache, Conversation
 from app.config import settings
 from app.routers.knowledge import get_rag_service
 
 router = APIRouter(prefix="/chat", tags=["对话"])
+
+# 保留最近10条历史消息
+MAX_HISTORY_MESSAGES = 10
 
 def _get_llm_client() -> OpenAI:
     """获取 LLM 客户端"""
@@ -134,6 +137,45 @@ def _build_db_summary_messages(context: str, question: str) -> list[dict]:
         {"role": "system", "content": system},
         {"role": "user", "content": question},
     ]
+
+
+def _merge_history_into_messages(base_messages: list[dict], history: List[dict]) -> list[dict]:
+    """
+    将历史对话插入到 LLM messages 中。
+    
+    规则：
+    - 历史只使用 role/content 字段，忽略其他元数据
+    - 最多保留 MAX_HISTORY_MESSAGES 条
+    - 如有 system 提示，则放在最前面，其次是历史消息，最后是当前用户问题
+    """
+    if not history:
+        return base_messages
+
+    # 规范化历史消息
+    normalized: List[dict] = []
+    for item in history:
+        role = item.get("role")
+        content = item.get("content")
+        if role in ("user", "assistant") and content:
+            normalized.append({"role": role, "content": content})
+
+    if not normalized:
+        return base_messages
+
+    # 只保留最近若干条
+    trimmed = normalized[-MAX_HISTORY_MESSAGES:]
+
+    if not base_messages:
+        return trimmed
+
+    first = base_messages[0]
+    if first.get("role") == "system":
+        # system 在最前面，其次历史，再是当前这轮的消息
+        rest = base_messages[1:]
+        return [first, *trimmed, *rest]
+
+    # 没有 system 提示时，直接把历史放在最前面
+    return [*trimmed, *base_messages]
 
 def _is_list_question(question: str) -> bool:
     """列表/清单类问题"""
@@ -382,6 +424,17 @@ async def _prepare_messages(request: ChatRequest, db: AsyncSession) -> tuple[lis
     question = request.question.strip()
     rag = get_rag_service()
     folder_ids = []
+    # 加载会话历史（如果有）
+    history_messages: List[dict] = []
+    if request.conversation_id:
+        result = await db.execute(
+            select(Conversation).where(Conversation.id == request.conversation_id)
+        )
+        conv = result.scalar_one_or_none()
+        if conv and conv.messages:
+            history = list(conv.messages)
+            history_messages = history[-MAX_HISTORY_MESSAGES:]
+
     if request.session_id:
         folder_ids = await _get_folder_ids_for_session(db, request.session_id, request.folder_ids)
         logger.info(f"Session: {request.session_id}, 关联 FolderIDs: {folder_ids}")
@@ -411,39 +464,46 @@ async def _prepare_messages(request: ChatRequest, db: AsyncSession) -> tuple[lis
             if not context:
                 context = "（暂无已入库的视频信息，请提醒用户可能需要先进行入库操作）"
             messages = _build_fallback_messages(context, question)
-            return messages, sources, question
+            return _merge_history_into_messages(messages, history_messages), sources, question
         messages = _build_direct_messages(question)
-        return messages, [], question
+        return _merge_history_into_messages(messages, history_messages), [], question
     # 3) 直接回答
     if route == "direct":
         title_context = await _get_video_titles_context(db, folder_ids, limit=50)
         messages = _build_direct_messages_with_context(title_context, question) if title_context else _build_direct_messages(question)
-        return messages, [], question
+        return _merge_history_into_messages(messages, history_messages), [], question
     # 4) 列表类问题
     if route == "db_list":
         if related is None:
             related = await _is_related_to_collection(db, folder_ids, question)
         if not related and not is_collection_intent:
-            return _build_direct_messages(question), [], question
+            messages = _build_direct_messages(question)
+            return _merge_history_into_messages(messages, history_messages), [], question
         context, sources = await _get_video_context(db, folder_ids, include_content=False, limit=50)
         if not context:
-            return _build_fallback_messages("（暂无信息，请入库）", question), sources, question
-        return _build_db_list_messages(context, question), sources, question
+            messages = _build_fallback_messages("（暂无信息，请入库）", question)
+            return _merge_history_into_messages(messages, history_messages), sources, question
+        messages = _build_db_list_messages(context, question)
+        return _merge_history_into_messages(messages, history_messages), sources, question
     # 5) 总结类问题
     if route == "db_content":
         if related is None:
             related = await _is_related_to_collection(db, folder_ids, question)
         if not related and not is_collection_intent:
-            return _build_direct_messages(question), [], question
+            messages = _build_direct_messages(question)
+            return _merge_history_into_messages(messages, history_messages), [], question
         context, sources = await _get_video_context(db, folder_ids, include_content=True, limit=None)
         if not context:
-            return _build_fallback_messages("（暂无信息，请入库）", question), sources, question
-        return _build_db_summary_messages(context, question), sources, question
+            messages = _build_fallback_messages("（暂无信息，请入库）", question)
+            return _merge_history_into_messages(messages, history_messages), sources, question
+        messages = _build_db_summary_messages(context, question)
+        return _merge_history_into_messages(messages, history_messages), sources, question
     # 6) 检查相关性
     if related is None:
         related = await _is_related_to_collection(db, folder_ids, question)
     if not related and not is_collection_intent:
-        return _build_direct_messages(question), [], question
+        messages = _build_direct_messages(question)
+        return _merge_history_into_messages(messages, history_messages), [], question
     # 7) 向量检索
     docs = []
     try:
@@ -456,14 +516,17 @@ async def _prepare_messages(request: ChatRequest, db: AsyncSession) -> tuple[lis
         context_parts, sources, seen_bvids = [], [], set()
         for doc in docs:
             bvid, title, content = doc.metadata.get("bvid", ""), doc.metadata.get("title", ""), doc.page_content.strip()
-            if content: context_parts.append(f"【{title}】\n{content}")
+            if content:
+                context_parts.append(f"【{title}】\n{content}")
             if bvid and bvid not in seen_bvids:
                 seen_bvids.add(bvid)
                 sources.append({"bvid": bvid, "title": title, "url": f"https://www.bilibili.com/video/{bvid}"})
-        return _build_rag_messages("\n\n---\n\n".join(context_parts), question), sources, question
+        messages = _build_rag_messages("\n\n---\n\n".join(context_parts), question)
+        return _merge_history_into_messages(messages, history_messages), sources, question
     # 兜底
     context, sources = await _get_video_context(db, folder_ids, include_content=False, limit=50)
-    return _build_fallback_messages(context or "（暂无入库信息）", question), sources, question
+    messages = _build_fallback_messages(context or "（暂无入库信息）", question)
+    return _merge_history_into_messages(messages, history_messages), sources, question
 
 @router.post("/ask", response_model=ChatResponse)
 async def ask_question(request: ChatRequest, db: AsyncSession = Depends(get_db)):
@@ -471,10 +534,66 @@ async def ask_question(request: ChatRequest, db: AsyncSession = Depends(get_db))
     if not request.question or not request.question.strip():
         raise HTTPException(status_code=400, detail="问题不能为空")
     try:
+        conversation_id: Optional[int] = request.conversation_id
+        conversation: Optional[Conversation] = None
+
+        # 按会话 ID 续接已有会话
+        if conversation_id is not None:
+            result = await db.execute(
+                select(Conversation).where(Conversation.id == conversation_id)
+            )
+            conversation = result.scalar_one_or_none()
+
+        # 如果没有找到，会新建一条会话记录
+        if conversation is None:
+            title = request.question.strip()[:50]
+            session_key = request.session_id or "anonymous"
+            conversation = Conversation(
+                session_id=session_key,
+                title=title,
+                messages=[],
+            )
+            db.add(conversation)
+            await db.flush()
+            conversation_id = conversation.id
+
         messages, sources, _ = await _prepare_messages(request, db)
         client = _get_llm_client()
-        response = client.chat.completions.create(model=settings.llm_model, messages=messages, temperature=0.5)
-        return ChatResponse(answer=response.choices[0].message.content or "", sources=sources[:5])
+        response = client.chat.completions.create(
+            model=settings.llm_model,
+            messages=messages,
+            temperature=0.5,
+        )
+        answer = response.choices[0].message.content or ""
+
+        # 记录本轮对话历史（仅非流式接口）
+        if conversation is not None:
+            from datetime import datetime
+
+            now = datetime.utcnow().isoformat()
+            history = list(conversation.messages or [])
+            history.append(
+                {
+                    "role": "user",
+                    "content": request.question,
+                    "timestamp": now,
+                }
+            )
+            history.append(
+                {
+                    "role": "assistant",
+                    "content": answer,
+                    "timestamp": now,
+                }
+            )
+            conversation.messages = history
+            await db.commit()
+
+        return ChatResponse(
+            answer=answer,
+            sources=sources[:5],
+            conversation_id=conversation_id,
+        )
     except HTTPException: raise
     except Exception as e:
         logger.error(f"问答失败: {e}")
@@ -486,14 +605,82 @@ async def ask_question_stream(request: ChatRequest, db: AsyncSession = Depends(g
     if not request.question or not request.question.strip():
         raise HTTPException(status_code=400, detail="问题不能为空")
     try:
+        # 会话管理逻辑与 /chat/ask 保持一致，便于多轮对话
+        conversation_id: Optional[int] = request.conversation_id
+        conversation: Optional[Conversation] = None
+
+        if conversation_id is not None:
+            result = await db.execute(
+                select(Conversation).where(Conversation.id == conversation_id)
+            )
+            conversation = result.scalar_one_or_none()
+
+        if conversation is None:
+            title = request.question.strip()[:50]
+            session_key = request.session_id or "anonymous"
+            conversation = Conversation(
+                session_id=session_key,
+                title=title,
+                messages=[],
+            )
+            db.add(conversation)
+            await db.flush()
+            conversation_id = conversation.id
+
         messages, sources, _ = await _prepare_messages(request, db)
         client = _get_llm_client()
+
         def generate():
-            stream = client.chat.completions.create(model=settings.llm_model, messages=messages, temperature=0.5, stream=True)
+            # 累积完整回答内容，便于写入对话历史
+            answer_parts: list[str] = []
+            stream = client.chat.completions.create(
+                model=settings.llm_model,
+                messages=messages,
+                temperature=0.5,
+                stream=True,
+            )
             for chunk in stream:
                 delta = chunk.choices[0].delta
-                if delta and delta.content: yield delta.content
-            yield f"\n[[SOURCES_JSON]]{json.dumps(sources, ensure_ascii=False)}"
+                if delta and delta.content:
+                    answer_parts.append(delta.content)
+                    yield delta.content
+
+            # 在流结束后写入对话历史
+            answer = "".join(answer_parts)
+            if conversation is not None and answer:
+                from datetime import datetime
+
+                now = datetime.utcnow().isoformat()
+                history = list(conversation.messages or [])
+                history.append(
+                    {
+                        "role": "user",
+                        "content": request.question,
+                        "timestamp": now,
+                    }
+                )
+                history.append(
+                    {
+                        "role": "assistant",
+                        "content": answer,
+                        "timestamp": now,
+                    }
+                )
+                conversation.messages = history
+                # 使用独立事务提交，避免在流式生成器中抛出异常
+                try:
+                    import anyio  # type: ignore
+                    anyio.from_thread.run(db.commit)
+                except Exception:
+                    # 出现提交问题时不影响主流程
+                    logger.warning("流式对话历史写入失败", exc_info=True)
+
+            meta = {
+                "sources": sources,
+                "conversation_id": conversation_id,
+            }
+            yield f"\n[[SOURCES_JSON]]{json.dumps(meta, ensure_ascii=False)}"
+
         return StreamingResponse(generate(), media_type="text/plain; charset=utf-8")
     except HTTPException: raise
     except Exception as e:

--- a/app/routers/chat.py
+++ b/app/routers/chat.py
@@ -4,7 +4,10 @@ Bilibili RAG 知识库系统
 """
 import re
 import json
-from typing import List, Optional
+import anyio
+from datetime import datetime
+from typing import List, Optional, Tuple
+
 from fastapi import APIRouter, HTTPException, Depends
 from fastapi.responses import StreamingResponse
 from loguru import logger
@@ -13,15 +16,63 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from openai import OpenAI
 from langchain.schema import Document
 
-from app.database import get_db
+from app.database import get_db, get_db_context
 from app.models import ChatRequest, ChatResponse, FavoriteFolder, FavoriteVideo, VideoCache, Conversation
 from app.config import settings
 from app.routers.knowledge import get_rag_service
 
 router = APIRouter(prefix="/chat", tags=["对话"])
 
-# 保留最近10条历史消息
 MAX_HISTORY_MESSAGES = 10
+
+
+async def _get_or_create_conversation(db: AsyncSession, request: ChatRequest) -> Tuple[int, Conversation]:
+    """获取或创建会话，返回 (conversation_id, conversation)"""
+    conversation_id: Optional[int] = request.conversation_id
+    conversation: Optional[Conversation] = None
+    if conversation_id is not None:
+        result = await db.execute(select(Conversation).where(Conversation.id == conversation_id))
+        conversation = result.scalar_one_or_none()
+    if conversation is None:
+        title = request.question.strip()[:50]
+        session_key = request.session_id or "anonymous"
+        conversation = Conversation(session_id=session_key, title=title, messages=[])
+        db.add(conversation)
+        await db.flush()
+        conversation_id = conversation.id
+    return conversation_id, conversation
+
+
+async def _do_append_turn(
+    session: AsyncSession, conversation_id: int, user_content: str, assistant_content: str
+) -> None:
+    """核心写入逻辑：追加一轮 user/assistant 对话到会话"""
+    result = await session.execute(select(Conversation).where(Conversation.id == conversation_id))
+    conv = result.scalar_one_or_none()
+    if conv is None:
+        return
+    now = datetime.utcnow().isoformat()
+    history = list(conv.messages or [])
+    history.append({"role": "user", "content": user_content, "timestamp": now})
+    history.append({"role": "assistant", "content": assistant_content, "timestamp": now})
+    conv.messages = history
+    await session.commit()
+
+
+async def _append_conversation_turn(
+    db: AsyncSession, conversation_id: int, user_content: str, assistant_content: str
+) -> None:
+    """向会话追加一轮对话（用于非流式接口，复用请求 session）"""
+    await _do_append_turn(db, conversation_id, user_content, assistant_content)
+
+
+async def _save_conversation_turn_standalone(
+    conversation_id: int, user_content: str, assistant_content: str
+) -> None:
+    """用独立会话保存一轮对话（用于流式接口，在 generator 内调用）"""
+    async with get_db_context() as session:
+        await _do_append_turn(session, conversation_id, user_content, assistant_content)
+
 
 def _get_llm_client() -> OpenAI:
     """获取 LLM 客户端"""
@@ -534,29 +585,7 @@ async def ask_question(request: ChatRequest, db: AsyncSession = Depends(get_db))
     if not request.question or not request.question.strip():
         raise HTTPException(status_code=400, detail="问题不能为空")
     try:
-        conversation_id: Optional[int] = request.conversation_id
-        conversation: Optional[Conversation] = None
-
-        # 按会话 ID 续接已有会话
-        if conversation_id is not None:
-            result = await db.execute(
-                select(Conversation).where(Conversation.id == conversation_id)
-            )
-            conversation = result.scalar_one_or_none()
-
-        # 如果没有找到，会新建一条会话记录
-        if conversation is None:
-            title = request.question.strip()[:50]
-            session_key = request.session_id or "anonymous"
-            conversation = Conversation(
-                session_id=session_key,
-                title=title,
-                messages=[],
-            )
-            db.add(conversation)
-            await db.flush()
-            conversation_id = conversation.id
-
+        conversation_id, conversation = await _get_or_create_conversation(db, request)
         messages, sources, _ = await _prepare_messages(request, db)
         client = _get_llm_client()
         response = client.chat.completions.create(
@@ -566,28 +595,8 @@ async def ask_question(request: ChatRequest, db: AsyncSession = Depends(get_db))
         )
         answer = response.choices[0].message.content or ""
 
-        # 记录本轮对话历史（仅非流式接口）
-        if conversation is not None:
-            from datetime import datetime
-
-            now = datetime.utcnow().isoformat()
-            history = list(conversation.messages or [])
-            history.append(
-                {
-                    "role": "user",
-                    "content": request.question,
-                    "timestamp": now,
-                }
-            )
-            history.append(
-                {
-                    "role": "assistant",
-                    "content": answer,
-                    "timestamp": now,
-                }
-            )
-            conversation.messages = history
-            await db.commit()
+        if conversation_id is not None:
+            await _append_conversation_turn(db, conversation_id, request.question, answer)
 
         return ChatResponse(
             answer=answer,
@@ -605,33 +614,14 @@ async def ask_question_stream(request: ChatRequest, db: AsyncSession = Depends(g
     if not request.question or not request.question.strip():
         raise HTTPException(status_code=400, detail="问题不能为空")
     try:
-        # 会话管理逻辑与 /chat/ask 保持一致，便于多轮对话
-        conversation_id: Optional[int] = request.conversation_id
-        conversation: Optional[Conversation] = None
-
-        if conversation_id is not None:
-            result = await db.execute(
-                select(Conversation).where(Conversation.id == conversation_id)
-            )
-            conversation = result.scalar_one_or_none()
-
-        if conversation is None:
-            title = request.question.strip()[:50]
-            session_key = request.session_id or "anonymous"
-            conversation = Conversation(
-                session_id=session_key,
-                title=title,
-                messages=[],
-            )
-            db.add(conversation)
-            await db.flush()
-            conversation_id = conversation.id
+        conversation_id, _ = await _get_or_create_conversation(db, request)
+        await db.commit()
 
         messages, sources, _ = await _prepare_messages(request, db)
         client = _get_llm_client()
+        question_text = request.question
 
         def generate():
-            # 累积完整回答内容，便于写入对话历史
             answer_parts: list[str] = []
             stream = client.chat.completions.create(
                 model=settings.llm_model,
@@ -645,40 +635,19 @@ async def ask_question_stream(request: ChatRequest, db: AsyncSession = Depends(g
                     answer_parts.append(delta.content)
                     yield delta.content
 
-            # 在流结束后写入对话历史
             answer = "".join(answer_parts)
-            if conversation is not None and answer:
-                from datetime import datetime
-
-                now = datetime.utcnow().isoformat()
-                history = list(conversation.messages or [])
-                history.append(
-                    {
-                        "role": "user",
-                        "content": request.question,
-                        "timestamp": now,
-                    }
-                )
-                history.append(
-                    {
-                        "role": "assistant",
-                        "content": answer,
-                        "timestamp": now,
-                    }
-                )
-                conversation.messages = history
-                # 使用独立事务提交，避免在流式生成器中抛出异常
+            if conversation_id is not None and answer:
                 try:
-                    import anyio  # type: ignore
-                    anyio.from_thread.run(db.commit)
+                    anyio.from_thread.run(
+                        _save_conversation_turn_standalone,
+                        conversation_id,
+                        question_text,
+                        answer,
+                    )
                 except Exception:
-                    # 出现提交问题时不影响主流程
                     logger.warning("流式对话历史写入失败", exc_info=True)
 
-            meta = {
-                "sources": sources,
-                "conversation_id": conversation_id,
-            }
+            meta = {"sources": sources, "conversation_id": conversation_id}
             yield f"\n[[SOURCES_JSON]]{json.dumps(meta, ensure_ascii=False)}"
 
         return StreamingResponse(generate(), media_type="text/plain; charset=utf-8")

--- a/frontend/components/ChatPanel.tsx
+++ b/frontend/components/ChatPanel.tsx
@@ -3,7 +3,9 @@
 import { useState, useRef, useEffect } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
-import { chatApi, knowledgeApi, KnowledgeStats } from "@/lib/api";
+import { chatApi, knowledgeApi, KnowledgeStats, API_BASE_URL } from "@/lib/api";
+
+const STREAM_MARKER = "[[SOURCES_JSON]]";
 
 interface Message {
   id: string;
@@ -47,29 +49,78 @@ export default function ChatPanel({ statsKey, sessionId, folderIds }: Props) {
     ]);
     setLoading(true);
 
+    const updateAssistant = (content: string, sources?: Array<{ bvid: string; title: string; url: string }>) =>
+      setMessages((prev) =>
+        prev.map((m) =>
+          m.id === assistantId ? { ...m, content, ...(sources !== undefined && { sources }) } : m
+        )
+      );
+
+    const setError = (msg: string) =>
+      updateAssistant(`错误: ${msg}`);
+
     try {
-      const res = await chatApi.ask(q, sessionId, folderIds, conversationId);
-      setConversationId(res.conversation_id ?? conversationId);
-      setMessages((prev) =>
-        prev.map((m) =>
-          m.id === assistantId
-            ? { ...m, content: res.answer, sources: res.sources }
-            : m
-        )
-      );
-    } catch (err) {
-      setMessages((prev) =>
-        prev.map((m) =>
-          m.id === assistantId
-            ? {
-                ...m,
-                content: `错误: ${
-                  err instanceof Error ? err.message : "请求失败"
-                }`,
+      const response = await fetch(`${API_BASE_URL}/chat/ask/stream`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          question: q,
+          session_id: sessionId,
+          folder_ids: folderIds,
+          conversation_id: conversationId ?? undefined,
+        }),
+      });
+
+      if (!response.ok || !response.body) {
+        throw new Error("流式接口不可用");
+      }
+
+      const reader = response.body.getReader();
+      const decoder = new TextDecoder("utf-8");
+      let buffer = "";
+      let inMeta = false;
+      let metaJson = "";
+
+      while (true) {
+        const { value, done } = await reader.read();
+        if (value) {
+          const chunk = decoder.decode(value, { stream: !done });
+          if (chunk) {
+            if (inMeta) {
+              metaJson += chunk;
+            } else {
+              buffer += chunk;
+              const idx = buffer.indexOf(STREAM_MARKER);
+              if (idx !== -1) {
+                const contentPart = buffer.slice(0, idx);
+                metaJson = buffer.slice(idx + STREAM_MARKER.length);
+                buffer = contentPart;
+                inMeta = true;
               }
-            : m
-        )
-      );
+              updateAssistant(buffer.trim());
+            }
+          }
+        }
+        if (done) break;
+      }
+
+      if (metaJson) {
+        try {
+          const meta = JSON.parse(metaJson) as { sources?: Array<{ bvid: string; title: string; url: string }>; conversation_id?: number };
+          if (meta.conversation_id != null) setConversationId(meta.conversation_id);
+          if (Array.isArray(meta.sources)) updateAssistant(buffer.trim(), meta.sources);
+        } catch {
+          // 解析失败不影响主文本
+        }
+      }
+    } catch (err) {
+      try {
+        const res = await chatApi.ask(q, sessionId, folderIds, conversationId);
+        setConversationId(res.conversation_id ?? conversationId);
+        updateAssistant(res.answer, res.sources);
+      } catch (fallbackErr) {
+        setError(err instanceof Error ? err.message : "请求失败");
+      }
     }
     setLoading(false);
   };

--- a/frontend/components/ChatPanel.tsx
+++ b/frontend/components/ChatPanel.tsx
@@ -104,13 +104,33 @@ export default function ChatPanel({ statsKey, sessionId, folderIds }: Props) {
         if (done) break;
       }
 
+      const remain = decoder.decode();
+      if (remain) {
+        if (inMeta) {
+          metaJson += remain;
+        } else {
+          buffer += remain;
+          updateAssistant(buffer.trim());
+        }
+      }
+
       if (metaJson) {
         try {
-          const meta = JSON.parse(metaJson) as { sources?: Array<{ bvid: string; title: string; url: string }>; conversation_id?: number };
-          if (meta.conversation_id != null) setConversationId(meta.conversation_id);
-          if (Array.isArray(meta.sources)) updateAssistant(buffer.trim(), meta.sources);
-        } catch {
-          // 解析失败不影响主文本
+          const parsed = JSON.parse(metaJson) as
+            | Array<{ bvid: string; title: string; url: string }>
+            | {
+                sources?: Array<{ bvid: string; title: string; url: string }>;
+                conversation_id?: number;
+              };
+          if (Array.isArray(parsed)) {
+            updateAssistant(buffer.trim(), parsed);
+          } else {
+            if (parsed.conversation_id != null) setConversationId(parsed.conversation_id);
+            if (Array.isArray(parsed.sources)) updateAssistant(buffer.trim(), parsed.sources);
+          }
+        } catch (parseErr) {
+          // 不阻断主文本，但保留调试信息，便于定位流式尾包解析问题
+          console.warn("流式尾包解析失败", parseErr, metaJson);
         }
       }
     } catch (err) {

--- a/frontend/components/ChatPanel.tsx
+++ b/frontend/components/ChatPanel.tsx
@@ -3,7 +3,7 @@
 import { useState, useRef, useEffect } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
-import { chatApi, knowledgeApi, KnowledgeStats, API_BASE_URL } from "@/lib/api";
+import { chatApi, knowledgeApi, KnowledgeStats } from "@/lib/api";
 
 interface Message {
   id: string;
@@ -23,8 +23,8 @@ export default function ChatPanel({ statsKey, sessionId, folderIds }: Props) {
   const [input, setInput] = useState("");
   const [loading, setLoading] = useState(false);
   const [stats, setStats] = useState<KnowledgeStats | null>(null);
+  const [conversationId, setConversationId] = useState<number | null>(null);
   const endRef = useRef<HTMLDivElement>(null);
-  const marker = "[[SOURCES_JSON]]";
 
   useEffect(() => {
     knowledgeApi.getStats().then(setStats).catch(() => { });
@@ -48,90 +48,28 @@ export default function ChatPanel({ statsKey, sessionId, folderIds }: Props) {
     setLoading(true);
 
     try {
-      const response = await fetch(`${API_BASE_URL}/chat/ask/stream`, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          question: q,
-          session_id: sessionId,
-          folder_ids: folderIds,
-        }),
-      });
-
-      if (!response.ok || !response.body) {
-        throw new Error("流式接口不可用");
-      }
-
-      const reader = response.body.getReader();
-      const decoder = new TextDecoder("utf-8");
-      let done = false;
-      let buffer = "";
-      let sourcesJson = "";
-      let inSources = false;
-
-      while (!done) {
-        const { value, done: doneReading } = await reader.read();
-        done = doneReading;
-        if (value) {
-          const chunk = decoder.decode(value, { stream: !done });
-          if (chunk) {
-            if (inSources) {
-              sourcesJson += chunk;
-            } else {
-              buffer += chunk;
-              const markerIndex = buffer.indexOf(marker);
-              if (markerIndex !== -1) {
-                const contentPart = buffer.slice(0, markerIndex);
-                sourcesJson = buffer.slice(markerIndex + marker.length);
-                buffer = contentPart;
-                inSources = true;
+      const res = await chatApi.ask(q, sessionId, folderIds, conversationId);
+      setConversationId(res.conversation_id ?? conversationId);
+      setMessages((prev) =>
+        prev.map((m) =>
+          m.id === assistantId
+            ? { ...m, content: res.answer, sources: res.sources }
+            : m
+        )
+      );
+    } catch (err) {
+      setMessages((prev) =>
+        prev.map((m) =>
+          m.id === assistantId
+            ? {
+                ...m,
+                content: `错误: ${
+                  err instanceof Error ? err.message : "请求失败"
+                }`,
               }
-              setMessages((prev) =>
-                prev.map((m) =>
-                  m.id === assistantId ? { ...m, content: buffer } : m
-                )
-              );
-            }
-          }
-        }
-      }
-
-      if (sourcesJson) {
-        try {
-          const parsed = JSON.parse(sourcesJson);
-          if (Array.isArray(parsed)) {
-            setMessages((prev) =>
-              prev.map((m) =>
-                m.id === assistantId ? { ...m, sources: parsed } : m
-              )
-            );
-          }
-        } catch {
-          // 忽略解析错误，避免影响主文本
-        }
-      }
-    } catch (e) {
-      try {
-        const res = await chatApi.ask(q, sessionId, folderIds);
-        setMessages((prev) =>
-          prev.map((m) =>
-            m.id === assistantId ? { ...m, content: res.answer, sources: res.sources } : m
-          )
-        );
-      } catch (err) {
-        setMessages((prev) =>
-          prev.map((m) =>
-            m.id === assistantId
-              ? {
-                  ...m,
-                  content: `错误: ${err instanceof Error ? err.message : "请求失败"}`,
-                }
-              : m
-          )
-        );
-      }
+            : m
+        )
+      );
     }
     setLoading(false);
   };
@@ -146,7 +84,14 @@ export default function ChatPanel({ statsKey, sessionId, folderIds }: Props) {
           )}
         </div>
         {messages.length > 0 && (
-          <button onClick={() => setMessages([])} className="btn btn-ghost" title="清空">
+          <button
+            onClick={() => {
+              setMessages([]);
+              setConversationId(null);
+            }}
+            className="btn btn-ghost"
+            title="清空"
+          >
             清空对话
           </button>
         )}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -157,6 +157,7 @@ export interface ChatResponse {
         title: string;
         url: string;
     }>;
+    conversation_id?: number;
 }
 
 // ==================== API 函数 ====================
@@ -279,10 +280,15 @@ export const knowledgeApi = {
 // 对话相关
 export const chatApi = {
     // 提问
-    ask: (question: string, sessionId?: string, folderIds?: number[]) =>
+    ask: (question: string, sessionId?: string, folderIds?: number[], conversationId?: number | null) =>
         request<ChatResponse>("/chat/ask", {
             method: "POST",
-            body: JSON.stringify({ question, session_id: sessionId, folder_ids: folderIds }),
+            body: JSON.stringify({
+                question,
+                session_id: sessionId,
+                folder_ids: folderIds,
+                conversation_id: conversationId ?? undefined,
+            }),
         }),
 
     // 搜索


### PR DESCRIPTION
Closes #2

## 实现内容
- 新增 `Conversation` 模型，持久化对话会话
- 支持多轮对话：通过 `conversation_id` 续接历史，LLM 上下文注入最近 10 条消息
- 前端 ChatPanel 接入会话管理，清空对话时重置 `conversation_id`
- `/chat/ask` 与 `/chat/ask/stream` 均支持会话存储；前端使用流式接口 `/chat/ask/stream`，流结束后解析 `conversation_id` 与 sources 以支持多轮

