### PR TITLE
支持用户历史记录查询

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,8 @@ env/
 *.swp
 *.swo
 *~
+.claude
+.history
 
 # 环境变量
 .env

--- a/app/models.py
+++ b/app/models.py
@@ -174,3 +174,14 @@ class ChatResponse(BaseModel):
     """对话响应"""
     answer: str
     sources: list[dict]  # 来源视频列表
+
+
+class TitleRequest(BaseModel):
+    """标题生成请求"""
+    question: str
+    answer: str
+
+
+class TitleResponse(BaseModel):
+    """标题生成响应"""
+    title: str

--- a/app/routers/chat.py
+++ b/app/routers/chat.py
@@ -16,7 +16,7 @@ from openai import OpenAI
 from langchain.schema import Document
 
 from app.database import get_db
-from app.models import ChatRequest, ChatResponse, FavoriteFolder, FavoriteVideo, VideoCache
+from app.models import ChatRequest, ChatResponse, TitleRequest, TitleResponse, FavoriteFolder, FavoriteVideo, VideoCache
 from app.config import settings
 from app.routers.knowledge import get_rag_service
 from app.services.retrieval import (
@@ -674,3 +674,58 @@ async def search_videos(query: str, k: int = 5):
     except Exception as e:
         logger.error(f"搜索失败: {e}")
         raise HTTPException(status_code=500, detail=f"搜索失败: {str(e)}")
+
+
+@router.post("/generate-title", response_model=TitleResponse)
+async def generate_title(req: TitleRequest):
+    """根据问答内容自动生成对话标题"""
+    if not req.question.strip():
+        raise HTTPException(status_code=400, detail="问题不能为空")
+
+    try:
+        client = _get_llm_client()
+
+        # 截取 answer 前 500 字做上下文，足够生成标题
+        answer_snippet = req.answer.strip()[:500] if req.answer.strip() else ""
+        context_block = (
+            f"用户问题：{req.question.strip()}\n"
+            f"助手回答（摘要）：{answer_snippet}"
+        ) if answer_snippet else f"用户问题：{req.question.strip()}"
+
+        system = (
+            "你是一个对话标题生成器。根据用户和助手的对话内容，生成一个简短的标题（不超过15个字）。\n"
+            "规则：\n"
+            "1. 只返回标题文本，不要加引号、句号或任何额外说明\n"
+            "2. 标题应该概括对话的核心主题，而不是描述对话行为\n"
+            "3. 使用中文\n"
+            "4. 如果问题是打招呼或闲聊，标题用对话中出现的具体主题；确实没有主题就用「闲聊」"
+        )
+
+        response = client.chat.completions.create(
+            model=settings.openai_model,
+            messages=[
+                {"role": "system", "content": system},
+                {"role": "user", "content": context_block},
+            ],
+            temperature=0.3,
+            max_tokens=32,
+        )
+
+        title = response.choices[0].message.content.strip()
+        # 去掉可能残留的引号
+        title = title.strip('"\'""''《》「」')
+        if not title:
+            title = req.question.strip()[:20]
+
+        logger.info(f"生成标题: {title}")
+        return TitleResponse(title=title)
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"生成标题失败: {e}")
+        # fallback: 用问题截断
+        fallback = req.question.strip()[:20]
+        if len(req.question.strip()) > 20:
+            fallback += "..."
+        return TitleResponse(title=fallback)

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -398,6 +398,228 @@ body {
   gap: 10px;
 }
 
+.chat-header-title {
+  min-width: 0;
+}
+
+.chat-actions {
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+/* ── 自定义对话下拉选择器 ── */
+.conversation-dropdown {
+  position: relative;
+  min-width: 180px;
+  max-width: 280px;
+  user-select: none;
+}
+
+.conversation-dropdown-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 8px 16px;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  background: rgba(255, 255, 255, 0.7);
+  color: var(--ink-soft);
+  font-family: inherit;
+  font-size: 13px;
+  font-weight: 500;
+  line-height: 1.3;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  text-align: left;
+}
+
+.conversation-dropdown-trigger:hover {
+  border-color: rgba(217, 139, 43, 0.5);
+}
+
+.conversation-dropdown-trigger:focus-visible {
+  outline: none;
+  border-color: rgba(47, 124, 120, 0.6);
+  box-shadow: 0 0 0 3px rgba(47, 124, 120, 0.12);
+}
+
+.conversation-dropdown-trigger:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.conversation-dropdown-trigger-text {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 13px;
+}
+
+.conversation-dropdown-chevron {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  color: var(--muted);
+  transition: transform 0.2s ease;
+  margin-left: auto;
+}
+
+.conversation-dropdown.open .conversation-dropdown-chevron {
+  transform: rotate(180deg);
+}
+
+.conversation-dropdown-menu {
+  position: absolute;
+  top: calc(100% + 8px);
+  left: 50%;
+  transform: translateX(-50%);
+  min-width: 240px;
+  z-index: 100;
+  background: rgba(247, 241, 232, 0.97);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  box-shadow:
+    0 18px 45px var(--shadow),
+    0 0 0 1px rgba(0, 0, 0, 0.03);
+  backdrop-filter: blur(14px);
+  overflow: hidden;
+  animation: dropdownIn 0.16s ease;
+  max-height: 360px;
+  display: flex;
+  flex-direction: column;
+}
+
+.conversation-dropdown-list {
+  overflow-y: auto;
+  flex: 1 1 auto;
+  padding: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.conversation-dropdown-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  width: 100%;
+  padding: 9px 12px;
+  border-radius: 10px;
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--ink-soft);
+  font-family: inherit;
+  font-size: 13px;
+  line-height: 1.35;
+  cursor: pointer;
+  transition: all 0.15s ease;
+  text-align: left;
+}
+
+.conversation-dropdown-item:hover {
+  background: rgba(255, 255, 255, 0.8);
+  border-color: var(--border);
+  color: var(--ink);
+}
+
+.conversation-dropdown-item.active {
+  background: rgba(217, 139, 43, 0.08);
+  border-color: rgba(217, 139, 43, 0.25);
+  color: var(--accent-strong);
+  font-weight: 600;
+}
+
+.conversation-dropdown-item.active:hover {
+  background: rgba(217, 139, 43, 0.14);
+  border-color: rgba(217, 139, 43, 0.4);
+}
+
+.conversation-dropdown-item-label {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.conversation-dropdown-item-delete {
+  flex-shrink: 0;
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  transition: all 0.15s ease;
+  padding: 0;
+}
+
+.conversation-dropdown-item:hover .conversation-dropdown-item-delete {
+  opacity: 1;
+}
+
+.conversation-dropdown-item-delete:hover {
+  background: rgba(199, 68, 58, 0.1);
+  border-color: rgba(199, 68, 58, 0.25);
+  color: var(--danger);
+}
+
+.conversation-dropdown-divider {
+  height: 1px;
+  background: var(--border);
+  margin: 6px 8px;
+  opacity: 0.5;
+}
+
+.conversation-dropdown-item-new {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 10px 12px;
+  border: none;
+  background: transparent;
+  color: var(--teal);
+  font-family: inherit;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.15s ease;
+  text-align: left;
+  border-radius: 0;
+}
+
+.conversation-dropdown-item-new:hover {
+  background: rgba(47, 124, 120, 0.06);
+}
+
+.conversation-dropdown-empty {
+  padding: 24px 12px;
+  text-align: center;
+  font-size: 13px;
+  color: var(--muted);
+}
+
+@keyframes dropdownIn {
+  from {
+    opacity: 0;
+    transform: translateX(-50%) translateY(-6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(-50%) translateY(0);
+  }
+}
+
 .panel-title {
   font-size: 16px;
   font-weight: 600;

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -196,6 +196,7 @@ export default function Home() {
               <ChatPanel
                 statsKey={statsKey}
                 sessionId={auth.session}
+                userKey={auth.user}
                 folderIds={selectedFolderIds}
               />
             </section>

--- a/frontend/components/ChatPanel.tsx
+++ b/frontend/components/ChatPanel.tsx
@@ -4,49 +4,224 @@ import { useState, useRef, useEffect } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { chatApi, knowledgeApi, KnowledgeStats, API_BASE_URL } from "@/lib/api";
-
-interface Message {
-  id: string;
-  role: "user" | "assistant";
-  content: string;
-  sources?: Array<{ bvid: string; title: string; url: string }>;
-}
+import {
+  ChatMessage,
+  ConversationMeta,
+  createConversationMeta,
+  loadConversationMessages,
+  loadConversations,
+  normalizeUserKey,
+  persistConversationMessages,
+  persistConversations,
+  removeConversationMessages,
+  trimConversationTitle,
+} from "@/lib/chatStorage";
 
 interface Props {
   statsKey?: number;
   sessionId?: string;
+  userKey?: string;
   folderIds?: number[];
 }
 
-export default function ChatPanel({ statsKey, sessionId, folderIds }: Props) {
-  const [messages, setMessages] = useState<Message[]>([]);
+const SAVE_THROTTLE_MS = 400;
+
+export default function ChatPanel({ statsKey, sessionId, userKey, folderIds }: Props) {
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [conversations, setConversations] = useState<ConversationMeta[]>([]);
+  const [currentConversationId, setCurrentConversationId] = useState<string>("");
   const [input, setInput] = useState("");
   const [loading, setLoading] = useState(false);
+  const [dropdownOpen, setDropdownOpen] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
   const [stats, setStats] = useState<KnowledgeStats | null>(null);
   const endRef = useRef<HTMLDivElement>(null);
+  const saveTimerRef = useRef<number | null>(null);
+  const hasLoadedRef = useRef(false);
   const marker = "[[SOURCES_JSON]]";
   const contentStartMarker = "[[CONTENT_START]]";
+
+  const storageUserKey = normalizeUserKey(userKey);
+
+  const persistMessagesNow = (conversationId: string, nextMessages: ChatMessage[]) => {
+    persistConversationMessages(storageUserKey, conversationId, nextMessages);
+  };
+
+  const upsertConversationMeta = (conversationId: string, updater: (old: ConversationMeta) => ConversationMeta) => {
+    setConversations((prev) => {
+      const next = prev.map((item) => (item.id === conversationId ? updater(item) : item));
+      persistConversations(storageUserKey, next);
+      return next;
+    });
+  };
+
+  const ensureConversation = () => {
+    if (currentConversationId) return currentConversationId;
+    const created = createConversationMeta();
+    setConversations((prev) => {
+      const next = [created, ...prev];
+      persistConversations(storageUserKey, next);
+      return next;
+    });
+    setCurrentConversationId(created.id);
+    setMessages([]);
+    return created.id;
+  };
 
   useEffect(() => {
     knowledgeApi.getStats().then(setStats).catch(() => { });
   }, [statsKey]);
 
   useEffect(() => {
+    if (!storageUserKey) {
+      setConversations([]);
+      setCurrentConversationId("");
+      setMessages([]);
+      hasLoadedRef.current = false;
+      return;
+    }
+
+    const loaded = loadConversations(storageUserKey);
+
+    if (loaded.length === 0) {
+      const created = createConversationMeta();
+      setConversations([created]);
+      persistConversations(storageUserKey, [created]);
+      setCurrentConversationId(created.id);
+      setMessages([]);
+      hasLoadedRef.current = true;
+      return;
+    }
+
+    const active = loaded[0];
+    setConversations(loaded);
+    setCurrentConversationId(active.id);
+    setMessages(loadConversationMessages(storageUserKey, active.id));
+    hasLoadedRef.current = true;
+  }, [storageUserKey]);
+
+  useEffect(() => {
+    if (!hasLoadedRef.current || !storageUserKey || !currentConversationId) return;
+    if (saveTimerRef.current !== null) {
+      window.clearTimeout(saveTimerRef.current);
+    }
+    saveTimerRef.current = window.setTimeout(() => {
+      persistConversationMessages(storageUserKey, currentConversationId, messages);
+      saveTimerRef.current = null;
+    }, SAVE_THROTTLE_MS);
+
+    return () => {
+      if (saveTimerRef.current !== null) {
+        window.clearTimeout(saveTimerRef.current);
+        saveTimerRef.current = null;
+      }
+    };
+  }, [messages, currentConversationId, storageUserKey]);
+
+  useEffect(() => {
     endRef.current?.scrollIntoView({ behavior: "smooth" });
   }, [messages]);
+
+  // 点击下拉外部关闭
+  useEffect(() => {
+    if (!dropdownOpen) return;
+    const handler = (e: MouseEvent) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
+        setDropdownOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [dropdownOpen]);
+
+  const switchConversation = (targetId: string) => {
+    if (loading || targetId === currentConversationId) return;
+    if (!storageUserKey) return;
+    persistMessagesNow(currentConversationId, messages);
+    setCurrentConversationId(targetId);
+    setMessages(loadConversationMessages(storageUserKey, targetId));
+  };
+
+  const createNewConversation = () => {
+    if (loading) return;
+    const created = createConversationMeta();
+    setConversations((prev) => {
+      const next = [created, ...prev];
+      persistConversations(storageUserKey, next);
+      return next;
+    });
+    setCurrentConversationId(created.id);
+    setMessages([]);
+  };
+
+  const clearCurrentConversation = () => {
+    if (!currentConversationId) return;
+    setMessages([]);
+    persistMessagesNow(currentConversationId, []);
+    upsertConversationMeta(currentConversationId, (old) => ({
+      ...old,
+      updatedAt: Date.now(),
+    }));
+  };
+
+  const deleteCurrentConversation = () => {
+    if (!currentConversationId || !storageUserKey || loading) return;
+    if (!window.confirm("确认删除当前会话吗？")) return;
+
+    removeConversationMessages(storageUserKey, currentConversationId);
+
+    setConversations((prev) => {
+      const next = prev.filter((item) => item.id !== currentConversationId);
+      persistConversations(storageUserKey, next);
+      if (next.length === 0) {
+        const created = createConversationMeta();
+        persistConversations(storageUserKey, [created]);
+        setCurrentConversationId(created.id);
+        setMessages([]);
+        return [created];
+      }
+      setCurrentConversationId(next[0].id);
+      setMessages(loadConversationMessages(storageUserKey, next[0].id));
+      return next;
+    });
+  };
+
+  const clearAllConversations = () => {
+    if (!storageUserKey || loading) return;
+    if (!window.confirm("确认清空全部会话吗？此操作不可撤销。")) return;
+
+    conversations.forEach((item) => {
+      removeConversationMessages(storageUserKey, item.id);
+    });
+
+    const created = createConversationMeta();
+    persistConversations(storageUserKey, [created]);
+    setConversations([created]);
+    setCurrentConversationId(created.id);
+    setMessages([]);
+  };
 
   const send = async () => {
     if (!input.trim() || loading) return;
     const q = input.trim();
     setInput("");
+    const activeConversationId = ensureConversation();
     const userId = Date.now().toString();
     const assistantId = (Date.now() + 1).toString();
+    const needsTitle = (conversations.find((c) => c.id === activeConversationId)?.title ?? "新对话") === "新对话";
     setMessages((prev) => [
       ...prev,
       { id: userId, role: "user", content: q },
       { id: assistantId, role: "assistant", content: "", sources: [] },
     ]);
+    upsertConversationMeta(activeConversationId, (old) => ({
+      ...old,
+      updatedAt: Date.now(),
+    }));
     setLoading(true);
+
+    // 流式完成后用于生成标题的 answer 文本
+    let finalAnswer = "";
 
     try {
       const response = await fetch(`${API_BASE_URL}/chat/ask/stream`, {
@@ -163,9 +338,11 @@ export default function ChatPanel({ statsKey, sessionId, folderIds }: Props) {
         pendingSources = parseSources(legacySourcesJson);
       }
       revealSources();
+      finalAnswer = answerBuffer;
     } catch {
       try {
         const res = await chatApi.ask(q, sessionId, folderIds);
+        finalAnswer = res.answer;
         setMessages((prev) =>
           prev.map((m) =>
             m.id === assistantId ? { ...m, content: res.answer, sources: res.sources } : m
@@ -185,22 +362,130 @@ export default function ChatPanel({ statsKey, sessionId, folderIds }: Props) {
       }
     }
     setLoading(false);
+
+    // 自动生成标题：首轮问答结束后用 AI 生成
+    if (needsTitle && finalAnswer) {
+      try {
+        const titleRes = await chatApi.generateTitle(q, finalAnswer);
+        if (titleRes.title) {
+          upsertConversationMeta(activeConversationId, (old) => ({
+            ...old,
+            title: titleRes.title,
+            updatedAt: Date.now(),
+          }));
+        }
+      } catch {
+        // 生成标题失败时静默降级，不影响主流程
+      }
+    }
   };
 
   return (
     <div className="panel-inner">
       <div className="panel-header">
-        <div>
+        <div className="chat-header-title">
           <div className="panel-title">对话工作台</div>
           {stats && stats.total_videos > 0 && (
             <div className="panel-subtitle">已收录 {stats.total_videos} 个视频</div>
           )}
         </div>
-        {messages.length > 0 && (
-          <button onClick={() => setMessages([])} className="btn btn-ghost" title="清空">
-            清空对话
+        <div className="panel-actions chat-actions">
+          {/* 自定义对话下拉选择器 */}
+          <div className={`conversation-dropdown${dropdownOpen ? " open" : ""}`} ref={dropdownRef}>
+            <button
+              className="conversation-dropdown-trigger"
+              onClick={() => setDropdownOpen((v) => !v)}
+              disabled={loading}
+              title={conversations.find((c) => c.id === currentConversationId)?.title ?? "选择对话"}
+            >
+              <span className="conversation-dropdown-trigger-text">
+                {conversations.find((c) => c.id === currentConversationId)?.title ?? "新对话"}
+              </span>
+              <span className="conversation-dropdown-chevron">
+                ▼
+              </span>
+            </button>
+
+            {dropdownOpen && (
+              <div className="conversation-dropdown-menu">
+                {conversations.length === 0 ? (
+                  <div className="conversation-dropdown-empty">暂无对话</div>
+                ) : (
+                  <div className="conversation-dropdown-list">
+                    {conversations.map((item) => (
+                      <button
+                        key={item.id}
+                        className={`conversation-dropdown-item${item.id === currentConversationId ? " active" : ""}`}
+                        onClick={() => {
+                          switchConversation(item.id);
+                          setDropdownOpen(false);
+                        }}
+                        title={item.title}
+                      >
+                        <span className="conversation-dropdown-item-label">{item.title}</span>
+                        {conversations.length > 1 && (
+                          <span
+                            className="conversation-dropdown-item-delete"
+                            title="删除此对话"
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              if (!storageUserKey || loading) return;
+                              if (!window.confirm("确认删除此对话吗？")) return;
+                              removeConversationMessages(storageUserKey, item.id);
+                              setConversations((prev) => {
+                                const next = prev.filter((c) => c.id !== item.id);
+                                persistConversations(storageUserKey, next);
+                                if (next.length === 0) {
+                                  const created = createConversationMeta();
+                                  persistConversations(storageUserKey, [created]);
+                                  setCurrentConversationId(created.id);
+                                  setMessages([]);
+                                  setDropdownOpen(false);
+                                  return [created];
+                                }
+                                if (item.id === currentConversationId) {
+                                  setCurrentConversationId(next[0].id);
+                                  setMessages(loadConversationMessages(storageUserKey, next[0].id));
+                                }
+                                setDropdownOpen(false);
+                                return next;
+                              });
+                            }}
+                          >
+                            ×
+                          </span>
+                        )}
+                      </button>
+                    ))}
+                  </div>
+                )}
+                <div className="conversation-dropdown-divider" />
+                <button
+                  className="conversation-dropdown-item-new"
+                  onClick={() => {
+                    createNewConversation();
+                    setDropdownOpen(false);
+                  }}
+                  disabled={loading}
+                >
+                  + 新建对话
+                </button>
+              </div>
+            )}
+          </div>
+
+          <button onClick={deleteCurrentConversation} disabled={loading || conversations.length === 0} className="btn btn-ghost" title="删除当前会话">
+            删除
           </button>
-        )}
+          <button onClick={clearAllConversations} disabled={loading || conversations.length === 0} className="btn btn-ghost" title="清空全部会话">
+            清空全部
+          </button>
+          {messages.length > 0 && (
+            <button onClick={clearCurrentConversation} disabled={loading} className="btn btn-ghost" title="清空当前会话消息">
+              清空当前
+            </button>
+          )}
+        </div>
       </div>
 
       <div className="panel-body">

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -164,6 +164,10 @@ export interface ChatResponse {
     }>;
 }
 
+export interface TitleResponse {
+    title: string;
+}
+
 // ==================== API 函数 ====================
 
 // 认证相关
@@ -296,4 +300,11 @@ export const chatApi = {
             `/chat/search?query=${encodeURIComponent(query)}&k=${k}`,
             { method: "POST" }
         ),
+
+    // 生成对话标题
+    generateTitle: (question: string, answer: string) =>
+        request<TitleResponse>("/chat/generate-title", {
+            method: "POST",
+            body: JSON.stringify({ question, answer }),
+        }),
 };

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
本次修改补充了针对用户历史记录的查询能力，方便在对话、检索或管理场景下按用户维度追溯历史内容。主要包括历史记录查询接口或逻辑的完善、查询条件的收敛，以及对结果返回的整理，提升了历史数据的可用性和可追踪性。

变更点

新增或完善用户历史记录查询能力
支持按用户维度筛选历史数据
优化查询结果结构，便于前端展示或后续处理
补充必要的边界处理，避免空数据或越权查询

验证

已本地验证历史记录查询接口可正常返回结果
已确认不同用户场景下的查询隔离符合预期