### PR TITLE
fix: repair broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
 [演示视频](https://b23.tv/bGXyhjU)
 
 ## ⭐ Star History
-[![Star History Chart](https://api.star-history.com/svg?repos=via007/bilibili-rag&type=Date)](https://star-history.com/#via007/bilibili-rag&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=via007/bilibili-rag&type=Date)](https://star-history.dera.page/#via007/bilibili-rag&Date)
 
 ---
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -33,7 +33,7 @@ Bilibili demo video: [https://b23.tv/bGXyhjU](https://b23.tv/bGXyhjU)
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=via007/bilibili-rag&type=Date)](https://star-history.com/#via007/bilibili-rag&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=via007/bilibili-rag&type=Date)](https://star-history.dera.page/#via007/bilibili-rag&Date)
 
 ---
 


### PR DESCRIPTION
The star history chart in the README is currently broken because the previous provider hit GitHub stargazer API restrictions. This change points the chart at a working provider so the Star History section displays correctly again. Updates both README.md and README_EN.md.